### PR TITLE
[MOD] 생성자 주입 방식 개선

### DIFF
--- a/week4/src/main/java/madcamp/week4/service/MessageService.java
+++ b/week4/src/main/java/madcamp/week4/service/MessageService.java
@@ -1,6 +1,7 @@
 package madcamp.week4.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import madcamp.week4.dto.MessageDto;
 import madcamp.week4.dto.MessageResponseDto;
 import madcamp.week4.model.Message;
@@ -16,14 +17,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class MessageService {
 
-    @Autowired
-    private MessageRepository messageRepository;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private OrganizationRepository organizationRepository;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    private final OrganizationRepository organizationRepository;
 
     public Message saveMessage(Message message) {
         return messageRepository.save(message);

--- a/week4/src/main/java/madcamp/week4/service/OrganizationService.java
+++ b/week4/src/main/java/madcamp/week4/service/OrganizationService.java
@@ -1,6 +1,7 @@
 package madcamp.week4.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import madcamp.week4.model.Organization;
 import madcamp.week4.model.User;
 import madcamp.week4.repository.OrganizationRepository;
@@ -13,14 +14,10 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class OrganizationService {
 
-
-
-
-
-    @Autowired
-    private OrganizationRepository organizationRepository;
+    private final OrganizationRepository organizationRepository;
 
     // 방생성 (초대코드 받아오기)
     public Organization createOrganization(Organization organization){return organizationRepository.save(organization);}

--- a/week4/src/main/java/madcamp/week4/service/UserOrganizationService.java
+++ b/week4/src/main/java/madcamp/week4/service/UserOrganizationService.java
@@ -1,5 +1,6 @@
 package madcamp.week4.service;
 
+import lombok.RequiredArgsConstructor;
 import madcamp.week4.model.Organization;
 import madcamp.week4.model.User;
 import madcamp.week4.repository.OrganizationRepository;
@@ -9,13 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserOrganizationService {
 
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private OrganizationRepository organizationRepository;
+    private final UserRepository userRepository;
+    private final OrganizationRepository organizationRepository;
 
     public void removeUserFromOrganization(Long userId, Long organizationId) {
         User user = userRepository.findById(userId)

--- a/week4/src/main/java/madcamp/week4/service/UserService.java
+++ b/week4/src/main/java/madcamp/week4/service/UserService.java
@@ -1,5 +1,6 @@
 package madcamp.week4.service;
 
+import lombok.RequiredArgsConstructor;
 import madcamp.week4.dto.OrganizationResponseDto;
 import madcamp.week4.exception.CustomException;
 import madcamp.week4.model.Organization;
@@ -16,13 +17,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private OrganizationRepository organizationRepository;
+    private final UserRepository userRepository;
+    private final OrganizationRepository organizationRepository;
 
     public User signupUser(User user) {
         Optional<User> existingUser = userRepository.findUserByUserName(user.getUserName());


### PR DESCRIPTION
### 수정한 코드
- Service - Repository 생성자 주입을 위해 @RequiredArgsConstructor와 final 필드 추가
---

### 문제 상황
(Autowired X)
```
public class MyController {
    private MyService myService;

    public MyController() {
        this.myService = new MyService(); // 직접 객체를 생성함
    }

    public void test() {
        myService.doSomething();
    }
}
```
new ScheduleService();를 직접 사용 -> 의존성이 강하게 결합됨(High Coupling) 
new 키워드를 사용하면 Spring이 관리하는 빈이 아니므로, Spring의 의존성 주입이 동작하지 않음

---

### 해결 방법
Spring의 의존성 주입(DI, Dependency Injection)
: 객체 간의 의존 관계를 직접 코드에서 만들지 않고, 외부에서 주입받도록 하는 프로그래밍 기법
1. 생성자 주입(권장) 2. 필드 주입(비추천) 3. setter 주입(선택적 의존성이 필요할 때)
@Autowired는 이를 위한 방법 중 하나

**@Autowired**
- @Autowired가 붙은 필드나 생성자, 메서드에 스프링 컨테이너가 자동으로 적절한 빈(Bean)을 주입
- 필드 주입 권장 X, 생성자 주입 권장 (생성자가 하나면 자동 주입, 불변성 유지, 테스트가 용이, 순환 의존성 문제를 방지)

생성자 주입(권장)
- Spring이 ScheduleService 객체를 생성자에서 자동으로 주입해 줌.
- 테스트가 쉬워짐 (Mock 객체 주입 가능!)
- 순환 의존성 문제를 조기에 발견 가능

필드 주입(비추천)
- Spring 컨테이너 없이 실행할 경우 scheduleService가 null이 될 가능성이 있음
- 테스트하기 어려움 (Mock 주입이 불가능)
- 순환 의존성 문제를 디버깅하기 어려움
    - A → B, B → A 식으로 서로 의존하는 경우 무한 루프가 발생할 수 있음
    - 생성자 주입이면 실행 전에 오류 발생하지만, 필드 주입이면 실행 시 오류 발생

Spring 컨테이너가 자동으로 MyService 객체를 만들어서 주입

```
@RequiredArgsConstructor
public class ScheduleController {
    private final ScheduleService scheduleService;
    private final UserAuthService userAuthService;
}
```
를 하면
```
public ScheduleController(ScheduleService scheduleService, UserAuthService userAuthService) {
    this.scheduleService = scheduleService;
    this.userAuthService = userAuthService;
}
```
이런식으로 생성자 생성
-> Spring은 생성자가 하나만 있을 때 자동으로 @Autowired 없이도 의존성을 주입하므로, @Autowired가 필요 없음

---

### 관련 내용

@RequiredArgsConstructor - final이 붙은 필드, @NonNull이 붙은 필드 생성자를 자동으로 만들어 줌

final - userRepository는 반드시 생성자에서 초기화되어야 함 (생성자 주입을 강제하므로 NullPointerException 방지), 한 번 할당된 이후 값 변경 불가
final이 없는 경우)
@Service
public class UserService {
    private UserRepository userRepository; // final 없음

    public UserService() {} // 기본 생성자로 객체 생성 가능 (userRepository는 null)

    public void getUser(Long id) {
        userRepository.findById(id); // NullPointerException 발생 가능
    }
}
final이 없으므로, 객체를 new UserService()로 생성할 때 userRepository가 초기화되지 않을 수도 있음 
(NullPointerException이 발생할 가능)
