### PR TITLE
[MOD] entity 다대다 관계 및 생성자 수정

### DIFF
--- a/week4/src/main/java/madcamp/week4/controller/OrganizationController.java
+++ b/week4/src/main/java/madcamp/week4/controller/OrganizationController.java
@@ -30,14 +30,14 @@ public class OrganizationController {
     }
 
     // 특정 그룹을 눌렀을때 해당하는 사람들의 리스트의 파일이 모두 떠야함
-    @PostMapping("/users")
-    public ResponseEntity<List<UserResponseDto>> getUsersByOrganization(@RequestBody OrganizationIdRequest request) {
-        List<User> users = organizationService.getUsersByOrganizationId(request.getOrganizationId());
-        List<UserResponseDto> userDtos = users.stream()
-                .map(user -> new UserResponseDto(user.getUserId(), user.getName()))
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(userDtos);
-    }
+//    @PostMapping("/users")
+//    public ResponseEntity<List<UserResponseDto>> getUsersByOrganization(@RequestBody OrganizationIdRequest request) {
+//        List<User> users = organizationService.getUsersByOrganizationId(request.getOrganizationId());
+//        List<UserResponseDto> userDtos = users.stream()
+//                .map(user -> new UserResponseDto(user.getUserId(), user.getName()))
+//                .collect(Collectors.toList());
+//        return ResponseEntity.ok(userDtos);
+//    }
 
 
     //    public ResponseEntity<List<User>> getUsersByOrganization(@RequestBody OrganizationIdRequest request) {

--- a/week4/src/main/java/madcamp/week4/controller/UserController.java
+++ b/week4/src/main/java/madcamp/week4/controller/UserController.java
@@ -38,17 +38,17 @@ public class UserController {
     }
 
     // organization에 들어가기
-    @PostMapping("/joinOrganization")
-    public ResponseEntity<User> joinOrganization(@RequestBody OrganizationJoinRequest joinRequest) {
-        User updatedUser = userService.joinOrganization(joinRequest.getUserId(), joinRequest.getOrganizationInviteNumber());
-        return ResponseEntity.ok(updatedUser);
-    }
-
-    // user가 들어가있는 모든 그룹 보여주기
-    @PostMapping("/organizations")
-    public List<OrganizationResponseDto> getUserOrganizations(@RequestBody UserIdRequest request) {
-        return userService.getOrganizationsByUserId(request.getUserId());
-    }
+//    @PostMapping("/joinOrganization")
+//    public ResponseEntity<User> joinOrganization(@RequestBody OrganizationJoinRequest joinRequest) {
+//        User updatedUser = userService.joinOrganization(joinRequest.getUserId(), joinRequest.getOrganizationInviteNumber());
+//        return ResponseEntity.ok(updatedUser);
+//    }
+//
+//    // user가 들어가있는 모든 그룹 보여주기
+//    @PostMapping("/organizations")
+//    public List<OrganizationResponseDto> getUserOrganizations(@RequestBody UserIdRequest request) {
+//        return userService.getOrganizationsByUserId(request.getUserId());
+//    }
 //    public ResponseEntity<List<Organization>> getUserOrganizations(@RequestBody UserIdRequest request) {
 //        List<Organization> organizations = userService.getUserOrganizations(request.getUserId());
 //        return ResponseEntity.ok(organizations);

--- a/week4/src/main/java/madcamp/week4/model/Message.java
+++ b/week4/src/main/java/madcamp/week4/model/Message.java
@@ -1,12 +1,18 @@
 package madcamp.week4.model;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Message {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,10 +37,6 @@ public class Message {
     @ManyToOne
     @JoinColumn(name = "organization_id", referencedColumnName = "organizationId")
     private Organization organization;
-
-    public Message() {
-
-    }
 
     public void createMessage(String fromNickName, String messageDescription, LocalDateTime messageTime, Boolean isRead){
         this.fromNickName = fromNickName;

--- a/week4/src/main/java/madcamp/week4/model/Message.java
+++ b/week4/src/main/java/madcamp/week4/model/Message.java
@@ -1,10 +1,7 @@
 package madcamp.week4.model;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/week4/src/main/java/madcamp/week4/model/Organization.java
+++ b/week4/src/main/java/madcamp/week4/model/Organization.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import madcamp.week4.util.UniqueStringGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -13,6 +16,9 @@ import java.util.Random;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "organizationId")
 public class Organization {
 
@@ -26,20 +32,9 @@ public class Organization {
 
     private String organizationInviteNumber;
 
-    @ManyToMany(mappedBy = "organizations")
-    private List<User> users;
-
-    public Organization() {
-        this.organizationInviteNumber = UniqueStringGenerator.generateUniqueString();
-    }
-
     public void makeOrganization(String organizationName){
         this.organizationName = organizationName;
     }
 
-    public void removeUser(User user) {
-        this.users.remove(user);
-        user.getOrganizations().remove(this);
-    }
 
 }

--- a/week4/src/main/java/madcamp/week4/model/Organization.java
+++ b/week4/src/main/java/madcamp/week4/model/Organization.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import madcamp.week4.util.UniqueStringGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -18,7 +15,7 @@ import java.util.Random;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "organizationId")
 public class Organization {
 

--- a/week4/src/main/java/madcamp/week4/model/User.java
+++ b/week4/src/main/java/madcamp/week4/model/User.java
@@ -2,8 +2,7 @@ package madcamp.week4.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import java.util.List;
@@ -11,6 +10,9 @@ import java.util.List;
 // default
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "userId")
 public class User {
     @Id // pk
@@ -23,21 +25,5 @@ public class User {
 
     private String name;
 
-    @ManyToMany
-    @JoinTable(
-            name = "user_organization", // Name of the join table
-            joinColumns = @JoinColumn(name = "userId"), // Column for User
-            inverseJoinColumns = @JoinColumn(name = "groupId") // Column for Organization
-    )
-    private List<Organization> organizations;
 
-    // 생성자
-    public User() {
-
-    }
-
-    public void removeOrganization(Organization organization) {
-        this.organizations.remove(organization);
-        organization.getUsers().remove(this);
-    }
 }

--- a/week4/src/main/java/madcamp/week4/model/User.java
+++ b/week4/src/main/java/madcamp/week4/model/User.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "userId")
 public class User {
     @Id // pk

--- a/week4/src/main/java/madcamp/week4/model/UserOrganization.java
+++ b/week4/src/main/java/madcamp/week4/model/UserOrganization.java
@@ -1,0 +1,28 @@
+package madcamp.week4.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserOrganization {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userOrganizationId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+
+}

--- a/week4/src/main/java/madcamp/week4/model/UserOrganization.java
+++ b/week4/src/main/java/madcamp/week4/model/UserOrganization.java
@@ -1,16 +1,13 @@
 package madcamp.week4.model;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserOrganization {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/week4/src/main/java/madcamp/week4/service/OrganizationService.java
+++ b/week4/src/main/java/madcamp/week4/service/OrganizationService.java
@@ -29,11 +29,11 @@ public class OrganizationService {
     }
 
     // 특정 그룹을 눌렀을때 해당하는 사람들의 리스트의 파일이 모두 떠야함
-    public List<User> getUsersByOrganizationId(Long organizationId) {
-        return organizationRepository.findById(organizationId)
-                .map(Organization::getUsers)
-                .orElse(Collections.emptyList()); // 조직이 존재하지 않으면 빈 리스트 반환
-    }
+//    public List<User> getUsersByOrganizationId(Long organizationId) {
+//        return organizationRepository.findById(organizationId)
+//                .map(Organization::getUsers)
+//                .orElse(Collections.emptyList()); // 조직이 존재하지 않으면 빈 리스트 반환
+//    }
 
     public Organization findByInviteNumber(String inviteNumber) {
         return organizationRepository.findByOrganizationInviteNumber(inviteNumber).orElse(null);

--- a/week4/src/main/java/madcamp/week4/service/UserOrganizationService.java
+++ b/week4/src/main/java/madcamp/week4/service/UserOrganizationService.java
@@ -22,8 +22,8 @@ public class UserOrganizationService {
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new RuntimeException("Organization not found"));
 
-        user.removeOrganization(organization);
-        organization.removeUser(user);
+//        user.removeOrganization(organization);
+//        organization.removeUser(user);
 
         userRepository.save(user);
         organizationRepository.save(organization);

--- a/week4/src/main/java/madcamp/week4/service/UserService.java
+++ b/week4/src/main/java/madcamp/week4/service/UserService.java
@@ -49,28 +49,28 @@ public class UserService {
         throw new LoginException("로그인 실패"); // 로그인 실패 시 예외를 던집니다.
     }
 
-    public User joinOrganization(Long userId, String organizationInviteNumber) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
-
-        Organization organization = organizationRepository.findByOrganizationInviteNumber(organizationInviteNumber)
-                .orElseThrow(() -> new RuntimeException("Organization not found"));
-
-        if (user.getOrganizations().contains(organization)) {
-            throw new IllegalStateException("User is already a member of this organization");
-        }
-
-        user.getOrganizations().add(organization);
-        return userRepository.save(user);
-    }
-
-    public List<OrganizationResponseDto> getOrganizationsByUserId(Long userId) {
-        Optional<User> user = userRepository.findById(userId);
-        return user.map(u -> u.getOrganizations().stream()
-                        .map(org -> new OrganizationResponseDto(org.getOrganizationId(), org.getOrganizationName(), org.getOrganizationInviteNumber()))
-                        .collect(Collectors.toList()))
-                .orElse(Collections.emptyList());
-    }
+//    public User joinOrganization(Long userId, String organizationInviteNumber) {
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new RuntimeException("User not found"));
+//
+//        Organization organization = organizationRepository.findByOrganizationInviteNumber(organizationInviteNumber)
+//                .orElseThrow(() -> new RuntimeException("Organization not found"));
+//
+//        if (user.getOrganizations().contains(organization)) {
+//            throw new IllegalStateException("User is already a member of this organization");
+//        }
+//
+//        user.getOrganizations().add(organization);
+//        return userRepository.save(user);
+//    }
+//
+//    public List<OrganizationResponseDto> getOrganizationsByUserId(Long userId) {
+//        Optional<User> user = userRepository.findById(userId);
+//        return user.map(u -> u.getOrganizations().stream()
+//                        .map(org -> new OrganizationResponseDto(org.getOrganizationId(), org.getOrganizationName(), org.getOrganizationInviteNumber()))
+//                        .collect(Collectors.toList()))
+//                .orElse(Collections.emptyList());
+//    }
 
 
 }


### PR DESCRIPTION
### 수정한 코드
- User, Organization이 다대다 관계 -> UserOrganization 중간 테이블 생성
- lombok으로 생성자 통일
- removeUser, removeOrganization으로 발생한 에러로 인해 기존 코드 주석처리
---
### 개선 사항
- @ManyToMany를 사용하면 JPA가 내부적으로 JOIN을 많이 사용하기 때문에 성능이 떨어질 수 있음
(특히 데이터가 많아질수록 중간 테이블을 직접 다루는 것이 쿼리 최적화에 유리)
---
### 관련 내용
**@NoArgsConstructor(access = AccessLevel.PROTECTED)**
- 객체 생성 제한을 위해 PROTECTED 설정 (외부에서 직접 객체를 생성하지 못하도록 제한)
- JPA에서 엔티티를 사용할 때 필수적으로 설정해야 함 (프록시 객체 생성을 위해 필요)

**@AllArgsConstructor** 
- 모든 필드 값을 받는 생성자 자동 생성
- @Builder를 사용하려면 @AllArgsConstructor가 필요

**@Builder**
- 객체 생성 패턴
- 가독성과 유연성이 필요할때 좋아 복잡한 객체에 사용
(필드가 적고, 성능이 중요한 경우 -> 생성자가 적합)
