### PR TITLE
[FEAT] Redis를 사용한 RTR 기능 구현

### DIFF
--- a/week4/src/main/java/madcamp/week4/config/RedisConfig.java
+++ b/week4/src/main/java/madcamp/week4/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @RequiredArgsConstructor
@@ -16,10 +17,11 @@ public class RedisConfig {
 
     // redisTemplate 커스텀
     // SpringBoot는 기본적으로 RedisTemplate<Object, Object> + JdkSerializationRedisSerializer로 사용
+    // JdkSerializationRedisSerializer는 무거움 (성능 관점)
     // 모든 객체를 저장할 수 있도록 Object 타입, JDK 기본 직렬화 방식 (Serializable) 을 통해 바이트 형태로 저장
     // 직렬화된 바이트라서 CLI나 RedisInsight 같은 툴에서 봐도 해석이 안됨
-    @Bean
-    public RedisTemplate<String, String> redisTemplate() {
+    @Bean(name = "customStringRedisTemplate")
+    public RedisTemplate<String, String> stringRedisTemplate() {
 
         // RedisTemplate<K, V>는 Redis에서 Key-Value 저장소로 데이터를 다룰 수 있는 핵심 도구
         // 여기선 String 타입의 Key와 Value를 저장하기 위해 RedisTemplate<String, String>으로 선언하고 커스터마이징
@@ -31,6 +33,22 @@ public class RedisConfig {
         // Redis는 바이트 배열로 데이터를 저장 -> 객체를 직렬화/역직렬화하는 방식이 중요
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+
+    @Bean(name = "customObjectRedisTemplate")
+    public RedisTemplate<String, Object> objectRedisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(connectionFactory);
+
+        // 직렬화 방식 설정 (사람이 읽기 쉬운 JSON 형태)
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;
     }

--- a/week4/src/main/java/madcamp/week4/config/SecurityConfig.java
+++ b/week4/src/main/java/madcamp/week4/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 테스트용)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/api/user/signup", "/api/user/login", "/upload/glb"
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/api/users/signup", "/api/users/login", "/upload/glb"
                         ).permitAll() // 스웨거 허용
                         .anyRequest().authenticated()
                 )

--- a/week4/src/main/java/madcamp/week4/controller/UserController.java
+++ b/week4/src/main/java/madcamp/week4/controller/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
     // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<?> signUpUser(@RequestBody UserRequestDto userRequestDto, HttpServletResponse response){
-        userService.login(userRequestDto, response);
+        userService.signUp(userRequestDto, response);
         return ResponseEntity.ok("회원가입 성공!");
     }
 

--- a/week4/src/main/java/madcamp/week4/model/RefreshToken.java
+++ b/week4/src/main/java/madcamp/week4/model/RefreshToken.java
@@ -1,0 +1,35 @@
+package madcamp.week4.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.io.Serializable;
+
+/**
+ * implements Serializable interface 사용 이유:
+ * Redis는 내부적으로 객체를 저장할 때 JdkSerializationRedisSerializer/Jackson2JsonRedisSerializer 사용
+ * JdkSerializationRedisSerializer는 Serializable 인터페이스가 필요
+ * Key: refresh_token:1
+ * Value: {userId: 1, token: "...", issuedAt: ...}
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@RedisHash("refresh_token") // @RedisHash("prefix") -> Redis 키 이름을 prefix:{id} 형식으로 저장
+public class RefreshToken implements Serializable {
+
+    private Long userId;
+    @Id
+    private String token;
+    // 처음 로그인할 때 한 번만 저장하고 이후엔 갱신 X
+    private Long issuedAt;
+    @TimeToLive
+    private Long ttl;
+
+}

--- a/week4/src/main/java/madcamp/week4/repository/RefreshTokenRepository.java
+++ b/week4/src/main/java/madcamp/week4/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package madcamp.week4.repository;
+
+import madcamp.week4.model.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+    Optional<RefreshToken> findById(String token);
+
+}

--- a/week4/src/main/java/madcamp/week4/service/InviteCodeService.java
+++ b/week4/src/main/java/madcamp/week4/service/InviteCodeService.java
@@ -12,14 +12,14 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class InviteCodeService {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, String> stringRedisTemplate;
 
     private static final String INVITE_PREFIX = "invite:";
 
     @PostConstruct // Spring이 Bean을 생성한 직후에 자동으로 실행되는 초기화 메서드
     public void testRedisConnection() {
-        redisTemplate.opsForValue().set("ping", "pong");
-        String result = redisTemplate.opsForValue().get("ping");
+        stringRedisTemplate.opsForValue().set("ping", "pong");
+        String result = stringRedisTemplate.opsForValue().get("ping");
         System.out.println("Redis 연결 테스트 결과: " + result);
     }
 
@@ -27,20 +27,20 @@ public class InviteCodeService {
     public String generateAndStoreInviteCode(Long organizationId) {
         String inviteCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
         String key = INVITE_PREFIX + inviteCode;
-        redisTemplate.opsForValue().set(key, String.valueOf(organizationId), 10, TimeUnit.MINUTES);
+        stringRedisTemplate.opsForValue().set(key, String.valueOf(organizationId), 10, TimeUnit.MINUTES);
         return inviteCode;
     }
 
     // 초대코드로 조직 ID 조회
     public Long getOrganizationIdByInviteCode(String inviteCode) {
         String key = INVITE_PREFIX + inviteCode;
-        String organizationId = redisTemplate.opsForValue().get(key);
+        String organizationId = stringRedisTemplate.opsForValue().get(key);
         return organizationId != null ? Long.parseLong(organizationId) : null;
     }
 
     // 초대코드 사용 후 삭제
     public void removeInviteCode(String inviteCode) {
         String key = INVITE_PREFIX + inviteCode;
-        redisTemplate.delete(key);
+        stringRedisTemplate.delete(key);
     }
 }

--- a/week4/src/main/java/madcamp/week4/service/UserService.java
+++ b/week4/src/main/java/madcamp/week4/service/UserService.java
@@ -42,7 +42,7 @@ public class UserService {
 
         // 가입하자마자 로그인 토큰 발급
         String accessToken = jwtProvider.createAccessToken(user.getUserName(), user.getUserId());
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken(user.getUserId());
         jwtProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 
         user.updateRefreshToken(refreshToken);
@@ -59,7 +59,7 @@ public class UserService {
         }
 
         String accessToken = jwtProvider.createAccessToken(user.getUserName(), user.getUserId());
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken(user.getUserId());
         jwtProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 
         user.updateRefreshToken(refreshToken);


### PR DESCRIPTION
### RTR 추가한 이유
- 탈취된 Refresh Token의 재사용 방지
  - 기존 방식에서는 Refresh Token이 한 번 발급되면 만료 시간 전까지 계속 사용 가능
  - 만약 이 토큰이 탈취되면 제3자가 마음대로 AccessToken을 재발급받을 수 있는 위험
  - RTR을 적용하면 Refresh Token을 사용할 때마다 즉시 폐기 후 새로 발급 -> 재사용 불가능
#### RTR에서 Redis를 사용한 이유
- Redis는 인메모리 저장소이기 때문에 읽기/쓰기 속도가 매우 빠르며 DB 트랜잭션 지연 없이 실시간 처리에 적합함
-  Redis에 저장하면서 TTL을 설정하면 별도의 만료 관리 로직 없이 자동 삭제

### RTR 적용
- RefreshToken: Redis 기반 RefreshToken 저장 구조
- RedisConfig: Redis 설정 (JSON 직렬화)
- JwtProvider: Refresh Token 발급 및 회전 로직
- JwtAuthenticationFilter: 동작 흐름 수정

[**관련 내용 정리 블로그(JWT 인증에서 Refresh Token Rotation(RTR) 적용 방법과 필요성)**](https://velog.io/@ynsulr/RTR)
[**관련 내용 정리 블로그(JWT 인증 - RTR 적용)**](https://velog.io/@ynsulr/JWT-%EC%9D%B8%EC%A6%9D-RTR-%EC%A0%81%EC%9A%A9)